### PR TITLE
Fix typo in get_langauge method

### DIFF
--- a/defglot/defglot.lua
+++ b/defglot/defglot.lua
@@ -35,7 +35,7 @@ function M.init()
 end
 
 function M.get_langauge()
-	return M.langauge
+	return M.language
 end
 
 function M.get_text(key)


### PR DESCRIPTION
Method `get_langauge` always returns `nil` value, because of a typo in property name.
I've fixed this typo.